### PR TITLE
update qrcode version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "qrcode": "^0.8.2"
+    "qrcode": "^1.2.0"
   },
   "description": "An Angular 6 Component library for Generating QR (Quick Response ) Codes.",
   "homepage": "https://github.com/techiediaries/ngx-qrcode#readme",


### PR DESCRIPTION
The problem of webpack4 compilation in Angular5 is solved：
Module not found: Error: Can't resolve 'node-zlib-backport' in './node_modules/qrcode/node_modules/pngjs/lib'